### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,4 +1,6 @@
 name: Android CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/JacquesLife/RoutifyPOE/security/code-scanning/1](https://github.com/JacquesLife/RoutifyPOE/security/code-scanning/1)

The best way to fix the problem is to explicitly add a `permissions` block with the minimum permissions required by the workflow. Since the workflow only needs to checkout repository code and does not interact with pull requests, issues, or other parts of the GitHub API requiring write access, we should set `contents: read`. The permission can be set either at the workflow level (applies to all jobs), or at the job level (applies to a specific job). The standard practice and the CodeQL suggestion is to add it at the workflow level, directly beneath the workflow `name:` line and before the `on:` block in `.github/workflows/android.yml`.

No method, import, or further definition is required—just an appropriately placed YAML block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
